### PR TITLE
Update icu package download uri to one that exists

### DIFF
--- a/training/CMakeLists.txt
+++ b/training/CMakeLists.txt
@@ -37,7 +37,7 @@ if (MSVC AND NOT CPPAN_BUILD)
     message(STATUS "Downloading latest ICU binaries")
 
     file(DOWNLOAD
-        "http://download.icu-project.org/files/icu4c/56.1/icu4c-56_1-Win${ARCH_DIR_NAME}-msvc10.zip"
+        "https://github.com/unicode-org/icu/releases/download/release-56-1/icu4c-56_1-Win${ARCH_DIR_NAME}-msvc10.zip"
         "${icu_archive}"
         SHOW_PROGRESS
         INACTIVITY_TIMEOUT 60 # seconds


### PR DESCRIPTION
The old URI for the icu package points to a html page. Looks the files have been moved to github.